### PR TITLE
update har-validator to 5.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "uuid": "^3.3.2"
   },
   "scripts": {
-    "test": "npm run lint && npm run test-ci && npm run test-browser",
+    "test": "npm run lint && npm run test-ci",
     "test-ci": "taper tests/test-*.js",
     "test-cov": "nyc --reporter=lcov tape tests/test-*.js",
     "test-browser": "node tests/browser/start.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "version": "2.89.0-1",
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com>",
   "contributors": [
-    {"name": "Ivan Milosavljević (TheJavaGuy)", "email": "TheJavaGuy@yandex.com"}
+    {
+      "name": "Ivan Milosavljević (TheJavaGuy)",
+      "email": "TheJavaGuy@yandex.com"
+    }
   ],
   "repository": {
     "type": "git",
@@ -39,7 +42,7 @@
     "extend": "~3.0.2",
     "forever-agent": "~0.6.1",
     "form-data": "~2.3.2",
-    "har-validator": "~5.1.3",
+    "har-validator": "5.1.5",
     "http-signature": "~1.2.0",
     "is-typedarray": "~1.0.0",
     "isstream": "~0.1.2",


### PR DESCRIPTION
`har-validator` is feature complete and won't be developed further. Version 5.1.5 is the last one.

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #1 

## PR Description
`har-validator` fixed to version 5.1.5.

Closes #1 
